### PR TITLE
Handle Cloud Flare ips endpoint with or wothout trailing slash. 

### DIFF
--- a/foxglove/middleware.py
+++ b/foxglove/middleware.py
@@ -390,18 +390,8 @@ async def get_cloudflare_ips() -> List[IPRangeCounter]:
     """
 
     async def get_ips(v: Literal[4, 6]) -> List[IPRangeCounter]:
-        try:
-            r = await glove.http.get(f'https://www.cloudflare.com/ips-v{v}')
-            UnexpectedResponse.check(r)
-        except ValueError:
-            try:
-                logger.info('get_ips error, retry with trailing slash')
-                r = await glove.http.get(f'https://www.cloudflare.com/ips-v{v}/')
-                UnexpectedResponse.check(r)
-            except ValueError:
-                logger.critical('unhandled error in get_ips', exc_info=True)
-                raise
-
+        r = await glove.http.get(f'https://www.cloudflare.com/ips-v{v}', follow_redirects=True)
+        UnexpectedResponse.check(r)
         return [IPRangeCounter(ip) for ip in r.text.strip().split('\n')]
 
     v4_ips, v6_ips = await asyncio.gather(get_ips(4), get_ips(6))

--- a/foxglove/middleware.py
+++ b/foxglove/middleware.py
@@ -395,11 +395,11 @@ async def get_cloudflare_ips() -> List[IPRangeCounter]:
             UnexpectedResponse.check(r)
         except ValueError:
             try:
-                logger.info('get_cloudflare_ips get_ips add trailing slash')
+                logger.info('get_ips error, retry with trailing slash')
                 r = await glove.http.get(f'https://www.cloudflare.com/ips-v{v}/')
                 UnexpectedResponse.check(r)
             except ValueError:
-                logger.critical('unhandled error in get_cloudflare_ips', exc_info=True)
+                logger.critical('unhandled error in get_ips', exc_info=True)
                 raise
 
         return [IPRangeCounter(ip) for ip in r.text.strip().split('\n')]

--- a/foxglove/middleware.py
+++ b/foxglove/middleware.py
@@ -390,7 +390,7 @@ async def get_cloudflare_ips() -> List[IPRangeCounter]:
     """
 
     async def get_ips(v: Literal[4, 6]) -> List[IPRangeCounter]:
-        r = await glove.http.get(f'https://www.cloudflare.com/ips-v{v}')
+        r = await glove.http.get(f'https://www.cloudflare.com/ips-v{v}/')
         UnexpectedResponse.check(r)
         return [IPRangeCounter(ip) for ip in r.text.strip().split('\n')]
 


### PR DESCRIPTION
Fix for this issue https://twitter.com/mkarpitski/status/1496282244197011457?s=21

Tries the `https://www.cloudflare.com/ips-v{v}` first without the trailing slash and then with the slash. So code will still work, if, for some reason, it gets changed back. 

Also added extra logging to confirm the issue.  

