### PR TITLE
👽 Implement `_MockOriginalResponse.close()` method

### DIFF
--- a/foxglove/testing/test_client.py
+++ b/foxglove/testing/test_client.py
@@ -73,6 +73,9 @@ class _MockOriginalResponse:
     def isclosed(self) -> bool:
         return self.closed
 
+    def close(self) -> None:
+        self.closed = True
+
 
 class _Upgrade(Exception):
     def __init__(self, session: 'WebSocketTestSession') -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 from foxglove.testing import TestClient as Client
+from foxglove.testing.test_client import _MockOriginalResponse
 
 
 def test_index(client: Client):
@@ -97,3 +98,13 @@ def test_null_json_error(client: Client):
     assert client.post_json('/create-user/', {'first_name': 'Samuel\x00', 'last_name': 'Colvin'}, status=400) == {
         'detail': 'There was an error parsing the body'
     }
+
+
+def test_mock_original_response_close():
+    response = _MockOriginalResponse([])
+
+    assert response.isclosed() is False
+
+    response.close()
+
+    assert response.isclosed() is True


### PR DESCRIPTION
`urllib3` has `HTTPResponse.close()` method, see: https://urllib3.readthedocs.io/en/latest/reference/urllib3.response.html#urllib3.response.HTTPResponse.close

This PR adds an implementation of that method to the mock class.

The absence of this method causes `AttributedError` in some cases. See failing Hooky tests https://github.com/pydantic/hooky/actions/runs/5790562918/job/15693844592

While adding this method doesn't fix those tests completely implementing more of `HTTPResponse` protocol looks like a good idea.